### PR TITLE
Update naga to v28, Refactor Code, and Improve Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     name: Cargo check all
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -16,7 +16,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -29,7 +29,7 @@ jobs:
     name: Cargo test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ categories = ["game-development", "graphics"]
 include = ["/Cargo.toml", "/LICENSE", "/README.md", "/src/**"]
 
 [dependencies]
-naga = { version = "24.0", features = ["wgsl-in", "wgsl-out"] } # Breaking change to update - API takes Naga module
+naga = { version = "26.0", features = ["wgsl-in", "wgsl-out"] } # Breaking change to update - API takes Naga module
 unicode-ident = "1.0"
 
 # Used for main
 clap = { version = "4.5", features = ["cargo"], optional = true }
-codespan-reporting = { version = "0.12", optional = true }
+codespan-reporting = { version = "0.13", optional = true }
 
 [features]
 bin = ["clap", "codespan-reporting"]
@@ -25,3 +25,6 @@ bin = ["clap", "codespan-reporting"]
 [[bin]]
 name = "wgsl-minifier"
 required-features = ["bin"]
+
+[dev-dependencies]
+pretty_assertions = "1.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgsl-minifier"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 license = "MIT"
 
@@ -14,7 +14,7 @@ categories = ["development-tools::build-utils", "game-development", "graphics"]
 include = ["/Cargo.toml", "/LICENSE", "/README.md", "/src/**"]
 
 [dependencies]
-naga = { version = "27.0", features = ["wgsl-in", "wgsl-out"] }
+naga = { version = "28.0", features = ["wgsl-in", "wgsl-out"] }
 unicode-ident = "1.0"
 
 # Used for main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wgsl-minifier"
 version = "0.7.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 
 description = "A command-line tool for minifying WGSL shaders."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,16 +3,18 @@ name = "wgsl-minifier"
 version = "0.7.0"
 edition = "2021"
 license = "MIT"
+
 description = "A command-line tool for minifying WGSL shaders."
 homepage = "https://github.com/LucentFlux/wgsl-minifier"
 repository = "https://github.com/LucentFlux/wgsl-minifier"
+
 readme = "README.md"
 keywords = ["gamedev", "graphics", "wgsl", "wgpu", "shader"]
-categories = ["game-development", "graphics"]
+categories = ["development-tools::build-utils", "game-development", "graphics"]
 include = ["/Cargo.toml", "/LICENSE", "/README.md", "/src/**"]
 
 [dependencies]
-naga = { version = "26.0", features = ["wgsl-in", "wgsl-out"] } # Breaking change to update - API takes Naga module
+naga = { version = "27.0", features = ["wgsl-in", "wgsl-out"] }
 unicode-ident = "1.0"
 
 # Used for main
@@ -27,4 +29,4 @@ name = "wgsl-minifier"
 required-features = ["bin"]
 
 [dev-dependencies]
-pretty_assertions = "1.4.1"
+pretty_assertions = "1.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,10 +116,10 @@ fn remove_identifiers(module: &mut naga::Module) {
         global.ty = type_handle_mapping[&global.ty];
     }
     for (_, function) in module.functions.iter_mut() {
-        remove_fn_identifiers(&mut name_counter, function, &type_handle_mapping)
+        remove_fn_identifiers(&mut name_counter, function, &type_handle_mapping);
     }
     for entry in module.entry_points.iter_mut() {
-        remove_fn_identifiers(&mut name_counter, &mut entry.function, &type_handle_mapping)
+        remove_fn_identifiers(&mut name_counter, &mut entry.function, &type_handle_mapping);
     }
 }
 
@@ -140,6 +140,7 @@ fn is_numeric(c: char) -> bool {
 }
 
 /// Removes all the characters it can in some wgsl sourcecode without joining any keywords or identifiers together.
+#[must_use]
 pub fn minify_wgsl_source(src: &str) -> String {
     let mut src = Cow::<'_, str>::Borrowed(src);
 
@@ -197,19 +198,16 @@ pub fn minify_wgsl_source(src: &str) -> String {
     new_src = String::new();
     let mut to_drop_stack = Vec::new();
     for (i, c) in src.chars().enumerate() {
-        if let Some(outer_end) = parentheses.get(&i) {
-            if let Some(inner_end) = parentheses.get(&(i + 1)) {
-                if *outer_end == *inner_end + 1 {
-                    to_drop_stack.push(*outer_end);
-                    continue;
-                }
-            }
+        if let Some(outer_end) = parentheses.get(&i)
+        && let Some(inner_end) = parentheses.get(&(i + 1))
+        && *outer_end == *inner_end + 1 {
+            to_drop_stack.push(*outer_end);
+            continue;
         }
-        if let Some(next_to_skip) = to_drop_stack.last() {
-            if *next_to_skip == i {
-                to_drop_stack.pop();
-                continue;
-            }
+        if let Some(next_to_skip) = to_drop_stack.last()
+        && *next_to_skip == i {
+            to_drop_stack.pop();
+            continue;
         }
         new_src.push(c);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,13 +199,15 @@ pub fn minify_wgsl_source(src: &str) -> String {
     let mut to_drop_stack = Vec::new();
     for (i, c) in src.chars().enumerate() {
         if let Some(outer_end) = parentheses.get(&i)
-        && let Some(inner_end) = parentheses.get(&(i + 1))
-        && *outer_end == *inner_end + 1 {
+            && let Some(inner_end) = parentheses.get(&(i + 1))
+            && *outer_end == *inner_end + 1
+        {
             to_drop_stack.push(*outer_end);
             continue;
         }
         if let Some(next_to_skip) = to_drop_stack.last()
-        && *next_to_skip == i {
+            && *next_to_skip == i
+        {
             to_drop_stack.pop();
             continue;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ fn remove_identifiers(module: &mut naga::Module) {
 /// Does not remove names on entry points, or on constants with overrides.
 pub fn minify_module(module: &mut naga::Module) {
     // Compact
-    naga::compact::compact(module);
+    naga::compact::compact(module, naga::compact::KeepUnused::Yes);
     // Remove any remaining identifiers
     remove_identifiers(module);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,8 +76,10 @@ fn main() {
     let mut module = match naga::front::wgsl::parse_str(&input_shader) {
         Ok(module) => module,
         Err(e) => {
-            eprintln!("{}", e.emit_to_string_with_path(&input_file_name, &*input.to_string_lossy()));
-            eprintln!("failed to parse shader");
+            eprintln!(
+                "{}\nfailed to parse shader",
+                e.emit_to_string_with_path(&input_file_name, &*input.to_string_lossy())
+            );
             return;
         }
     };
@@ -109,7 +111,8 @@ fn main() {
         let files = SimpleFile::new(input_file_name.as_ref(), &source);
         let config = codespan_reporting::term::Config::default();
         let writer = StandardStream::stderr(ColorChoice::Auto);
-        term::emit_to_write_style(&mut writer.lock(), &config, &files, &diagnostic).expect("cannot write error");
+        term::emit_to_write_style(&mut writer.lock(), &config, &files, &diagnostic)
+            .expect("cannot write error");
     }
 
     // Now minify!

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ fn main() {
     let mut module = match naga::front::wgsl::parse_str(&input_shader) {
         Ok(module) => module,
         Err(e) => {
-            e.emit_to_stderr_with_path(&input_file_name, &*input.to_string_lossy());
+            eprintln!("{}", e.emit_to_string_with_path(&input_file_name, &*input.to_string_lossy()));
             eprintln!("failed to parse shader");
             return;
         }
@@ -109,7 +109,7 @@ fn main() {
         let files = SimpleFile::new(input_file_name.as_ref(), &source);
         let config = codespan_reporting::term::Config::default();
         let writer = StandardStream::stderr(ColorChoice::Auto);
-        term::emit(&mut writer.lock(), &config, &files, &diagnostic).expect("cannot write error");
+        term::emit_to_write_style(&mut writer.lock(), &config, &files, &diagnostic).expect("cannot write error");
     }
 
     // Now minify!

--- a/tests/hardcoded.rs
+++ b/tests/hardcoded.rs
@@ -1,5 +1,7 @@
 use wgsl_minifier::*;
 
+use pretty_assertions::assert_str_eq;
+
 fn minify(input_shader: &str) -> String {
     let mut module = naga::front::wgsl::parse_str(input_shader).unwrap();
 
@@ -47,7 +49,7 @@ fn minify_1() {
 
     let got = minify(src);
 
-    assert_eq!(expected, got);
+    assert_str_eq!(expected, got);
 }
 
 #[test]
@@ -83,5 +85,5 @@ fn minify_2() {
 
     let got = minify(src);
 
-    assert_eq!(expected, got);
+    assert_str_eq!(expected, got);
 }


### PR DESCRIPTION
This patch:
- Updates naga to v28
- Uses `pretty_assertions` in tests for colored diffs
- Updates to Rust 2024 edition
- Lints code
- Formats code
- It also updates CI deps