### PR TITLE
Updating to naga 28, adding KeepUnused enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgsl-minifier"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 description = "A command-line tool for minifying WGSL shaders."
@@ -12,7 +12,7 @@ categories = ["game-development", "graphics"]
 include = ["/Cargo.toml", "/LICENSE", "/README.md", "/src/**"]
 
 [dependencies]
-naga = { version = "24.0", features = ["wgsl-in", "wgsl-out"] } # Breaking change to update - API takes Naga module
+naga = { version = "28.0", features = ["wgsl-in", "wgsl-out"] } # Breaking change to update - API takes Naga module
 unicode-ident = "1.0"
 
 # Used for main

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To use this crate as a library, for example in a game engine or larger preproces
 let mut module = /* your source here, or */ naga::Module::default();
 
 // Now minify!
-wgsl_minifier::minify_module(&mut module);
+wgsl_minifier::minify_module(&mut module, wgsl_minifier::KeepUnused::No);
 
 // Write to WGSL string
 let mut validator = naga::valid::Validator::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
+/// Re-export of Naga's `KeepUnused` type.
+pub type KeepUnused = naga::compact::KeepUnused;
+
 const FIRST_LETTERS: [char; 52] = [
     'A', 'a', 'B', 'b', 'C', 'c', 'D', 'd', 'E', 'e', 'F', 'f', 'G', 'g', 'H', 'h', 'I', 'i', 'J',
     'j', 'K', 'k', 'L', 'l', 'M', 'm', 'N', 'n', 'O', 'o', 'P', 'p', 'Q', 'q', 'R', 'r', 'S', 's',
@@ -128,9 +131,9 @@ fn remove_identifiers(module: &mut naga::Module) {
 /// This method has to re-create the types arena, as changing the names may mean the types are no longer unique.
 ///
 /// Does not remove names on entry points, or on constants with overrides.
-pub fn minify_module(module: &mut naga::Module) {
+pub fn minify_module(module: &mut naga::Module, keep_unused: KeepUnused) {
     // Compact
-    naga::compact::compact(module);
+    naga::compact::compact(module, keep_unused);
     // Remove any remaining identifiers
     remove_identifiers(module);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ fn main() {
     }
 
     // Now minify!
-    minify_module(&mut module, KeepUnused::Yes);
+    minify_module(&mut module, KeepUnused::No);
 
     // Write to string
     let mut validator = naga::valid::Validator::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use codespan_reporting::{
         termcolor::{ColorChoice, StandardStream},
     },
 };
-use wgsl_minifier::{minify_module, minify_wgsl_source};
+use wgsl_minifier::{minify_module, minify_wgsl_source, KeepUnused};
 fn main() {
     let matches = command!()
         .arg(
@@ -113,7 +113,7 @@ fn main() {
     }
 
     // Now minify!
-    minify_module(&mut module);
+    minify_module(&mut module, KeepUnused::Yes);
 
     // Write to string
     let mut validator = naga::valid::Validator::new(

--- a/tests/hardcoded.rs
+++ b/tests/hardcoded.rs
@@ -4,7 +4,7 @@ fn minify(input_shader: &str) -> String {
     let mut module = naga::front::wgsl::parse_str(input_shader).unwrap();
 
     // Now minify!
-    minify_module(&mut module);
+    minify_module(&mut module, KeepUnused::Yes);
 
     // Write to string
     let mut validator = naga::valid::Validator::new(


### PR DESCRIPTION
Naga added a KeepUnused enum (not a bool for some reason) to their `compact` function, so I re-exported it and added it as an argument to `minify_module`. It looks like `KeepUnused::Yes` preserves the original behavior in tests, so I use that in the original tests. I default to `KeepUnused::No` in the binary version of the crate and recommend its use in the Readme.

Not sure if these are the necessarily the best choices, so feel free to change them.